### PR TITLE
fix(transcription): surface invalid API key in network-error path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,5 +72,8 @@ docker/tmp/
 landing-screenshot.png
 video_chat_and_translator/landing-screenshot.png
 
+# === Git worktrees (HW-3 orchestration) ===
+.worktrees/
+
 # === Misc ===
 *.bak

--- a/docs/orchestration/demo-runs/issue-24.md
+++ b/docs/orchestration/demo-runs/issue-24.md
@@ -1,0 +1,109 @@
+# Demo run — Issue #24 (HW-3 Часть 2)
+
+Демонстрационный прогон orchestration-инфраструктуры на реальной задаче из репозитория. Показывает, как одна команда `scripts/start-task.sh` создаёт изолированный worktree, инициализирует его, запускает агента в отдельном zellij-табе и применяет routing-правило.
+
+## Задача
+
+- Issue: [#24 — Исправить ошибку неверного ключа](https://github.com/OlegPhenomenon/video-chat-and-translator/issues/24)
+- Симптом: при невалидном API-ключе транскрибации UI показывает общее сообщение «Не удалось выполнить запрос к провайдеру. Возможны проблемы сети или CORS», вместо реальной причины (401/неверный ключ).
+- Цель: пробросить настоящий код/текст ошибки от провайдера в UI.
+
+## Routing-решение
+
+| Параметр | Значение | Почему |
+|---|---|---|
+| `--type` | `bugfix` | Точечный фикс, без смены архитектуры |
+| Агент | claude (по таблице) | codex недоступен (лимиты), не релевантно |
+| Подсказка | rails-architecture-analyst sub-agent | Перед правкой нужно понять цепочку: где формируется сообщение, какие сервисы/контроллеры/JS-компоненты в ней участвуют |
+| Branch | `fix-24-transcription-error-text` | Префикс `fix-<номер>-...` |
+| Base | `main` | На момент демо HEAD = 964064b |
+
+## Команда запуска
+
+```bash
+scripts/start-task.sh fix-24-transcription-error-text --type bugfix --base main
+```
+
+Что делает скрипт:
+1. Создаёт worktree `.worktrees/fix-24-transcription-error-text/` и ветку `fix-24-transcription-error-text` от `main`.
+2. Запускает `scripts/init.sh` внутри worktree: `mise install`, копирует `.env*` и `.envrc` из main, `direnv allow`.
+3. Открывает новую zellij-вкладку с именем `fix-24-transcription-error-text`, cwd установлен в worktree.
+4. Стартует `claude` в этой вкладке.
+5. Печатает подсказку про `rails-architecture-analyst`.
+
+## Первая реплика агенту
+
+После того как claude поднялся в новом табе, скопировать туда:
+
+```
+Issue для работы: https://github.com/OlegPhenomenon/video-chat-and-translator/issues/24
+
+Перед правкой кода используй sub-agent rails-architecture-analyst, чтобы:
+1. Найти, где формируется сообщение «Не удалось выполнить запрос к провайдеру…»
+2. Построить полную цепочку: фронтенд (где показывается) → транспорт (как пробрасывается) → backend/Rails или прямой вызов провайдера → точка где теряется реальная причина ошибки.
+3. Предложить минимальное изменение, чтобы реальный текст ошибки от провайдера дошёл до UI.
+
+Не трогай архитектуру, не делай рефакторинг. Только точечный фикс с тестом.
+Когда план будет готов — покажи его и дождись подтверждения, перед тем как править код.
+```
+
+## Артефакты прогона
+
+Заполняются по факту демо.
+
+### Команда и её stdout
+
+```
+$ scripts/start-task.sh fix-24-transcription-error-text --type bugfix --base main
+
+<paste output>
+```
+
+### Worktree
+
+```
+$ git worktree list
+<paste>
+```
+
+### Ветка в локальном репо
+
+```
+$ git -C .worktrees/fix-24-transcription-error-text log --oneline -5
+<paste>
+```
+
+### Скриншот zellij
+
+`screenshots/hw-3/zellij-issue-24.png`
+
+### Diff после работы агента
+
+```
+$ git -C .worktrees/fix-24-transcription-error-text diff main..HEAD --stat
+<paste>
+```
+
+### PR (если открывался)
+
+- URL: <fill in>
+- Базовая ветка: main
+- Состояние: <draft/open/merged>
+
+## Самопроверка по критериям HW-3
+
+| Требование задания | Где проявилось |
+|---|---|
+| Мультиплексор | zellij 0.44.0, новый таб создан скриптом |
+| Изоляция через git worktree | `.worktrees/fix-24-transcription-error-text/`, отдельный рабочий каталог |
+| Шаг инициализации | `scripts/init.sh` — toolchain, env-перенос, direnv |
+| Routing-правило | `--type bugfix` → claude + rails-architecture-analyst hint |
+| Один реальный запуск | Этот документ + diff/PR |
+| Отротуена ли задача | Да, через таблицу в `docs/orchestration/routing.md` |
+| Где создался branch / worktree | См. секции выше |
+| Какой командой стартует execution | `scripts/start-task.sh ...` (одна команда) |
+| Проверяемый результат | Diff/PR + скриншот zellij |
+
+## Замечания после прогона
+
+<пишутся после демо: что сработало, что неудобно, что улучшить — для секции «отличный уровень» сдачи>

--- a/docs/orchestration/routing.md
+++ b/docs/orchestration/routing.md
@@ -1,0 +1,76 @@
+# Routing для агентных задач
+
+Документ описывает, как задача в этом репозитории попадает в нужного агента, режим и набор skill/sub-agent'ов. Используется `scripts/start-task.sh` через флаг `--type`.
+
+## Зачем нужен routing
+
+Не все задачи одинаковые. Для ревью PR не нужен агент с большим thinking-бюджетом. Для написания спецификации, наоборот, важна аккуратность к деталям и медленный режим. Без явного routing скрипт `start-task.sh` всегда стартует одну и ту же конфигурацию и теряет половину пользы от того, что у нас несколько инструментов.
+
+Routing — это таблица соответствий «тип задачи → выбранный агент → какие skill/sub-agent активировать → начальный промпт». `start-task.sh --type <task-type>` использует эту таблицу и собирает запуск.
+
+## Стек проекта (контекст для решений)
+
+- Backend: Rails (Ruby 3.4.8) во вложенной `video_chat_and_translator/`
+- Frontend: Inertia + React
+- Тесты: RSpec (бэкенд), Vitest (фронт), Capybara + Cuprite (system specs)
+- Документация и фичи: Memory Bank (`.memory-bank/`), feature-flow через `flows/feature-flow.md`
+- Доступные агенты: `claude` (Claude Code), `codex` (OpenAI Codex CLI — лимиты могут заканчиваться)
+
+## Таблица routing'а
+
+| `--type` | Агент | Подсказки skill / sub-agent | Когда выбирать |
+|---|---|---|---|
+| `spec` | claude | `rails-architecture-analyst`, `spec-reviewer:spec-review` | Создание `feature.md` или ревью спецификации в `.memory-bank/features/FT-XXX/` |
+| `feature` | claude | `rails-architecture-analyst`, при UI — `frontend-design` | Реализация фичи по уже одобренному плану |
+| `frontend` | claude | `frontend-design`, `playwright-cli` | UI/UX работа в `app/javascript/` (React + Inertia) |
+| `bugfix` | claude | `rails-architecture-analyst` | Точечный фикс из `TODO.md`, без смены архитектуры |
+| `test` | claude | `rails-qa-test-investigator` | Только тесты — RSpec system/unit, Vitest |
+| `review` | codex (fallback claude) | `pr-review-fix-loop:codex-pr-review` | Ревью своего PR перед merge |
+| `docs` | claude | `sc:document` | Обновление `docs/`, Memory Bank, README |
+| `refactor` | claude | `rails-architecture-analyst` | Рефакторинг существующего кода без новой функциональности |
+| `freeform` | claude | — | Когда тип не подходит ни под одну категорию; routing молча запускает claude |
+
+`codex` указан только для `review`, потому что для быстрого критического чтения PR он часто экономнее. Если лимиты codex исчерпаны — `start-task.sh` прозрачно откатывается на claude.
+
+## Как routing превращается в запуск
+
+`scripts/start-task.sh --type <type> <branch>` делает следующее:
+
+1. Создаёт worktree `.worktrees/<branch>` (см. `scripts/init.sh`).
+2. Берёт строку из таблицы выше по `<type>`.
+3. Выбирает binary (`claude` или `codex`), при недоступности codex — fallback на claude.
+4. Открывает таб zellij, стартует агента в worktree.
+5. Печатает в STDOUT подсказку, какие skill/sub-agent имеет смысл подключить руками в первой реплике агента (полностью автоматизировать выбор skill через CLI claude нельзя — он активируется внутри сессии).
+
+`--type` можно опустить — тогда применяется `freeform` (просто claude без подсказок).
+
+## Примеры запуска
+
+```bash
+# новая фича: создаём ветку, открываем claude в новом zellij-табе,
+# скрипт подскажет про rails-architecture-analyst
+scripts/start-task.sh ft-022-recordings --type feature
+
+# точечный фикс из TODO.md
+scripts/start-task.sh fix-signout-feedback --type bugfix
+
+# написание system spec из tech debt
+scripts/start-task.sh test-dashboard-system-specs --type test
+
+# ревью своего PR через codex (если есть лимиты), иначе claude
+scripts/start-task.sh review-ft-021 --type review --base ft-021-task-routing
+```
+
+## Принципы добавления новых типов
+
+1. Тип должен соответствовать **повторяющемуся** классу задач — если категория встречается раз в полгода, держи её в `freeform` и не плоди записи.
+2. Запись должна менять **хотя бы одно** реальное измерение запуска: агент, sub-agent, начальный промпт. Иначе это декоративный routing — то, против чего предупреждает HW-3.
+3. После добавления типа обнови таблицу здесь и `case` в `scripts/start-task.sh` синхронно. Они должны соответствовать друг другу.
+
+## Связанные материалы
+
+- Задание HW-3, Часть 2 — orchestration ([docs HW-3](https://ai-swe-1.thinknetica.com/week/3/homework/))
+- Курсовой материал — [Роутинг задач](https://ai-swe-1.thinknetica.com/materials/orchestration/task-routing/)
+- `scripts/start-task.sh` — реализация запуска
+- `scripts/init.sh` — инициализация worktree
+- `.memory-bank/flows/feature-flow.md` — процесс создания фич, в который встраивается routing для типов `spec` / `feature`

--- a/init.sh
+++ b/init.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-mise trust
-direnv allow
-
-# bundle
-# dip provision

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+  printf '[init] %s\n' "$*"
+}
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+log "worktree: $repo_root"
+
+if command -v mise >/dev/null 2>&1; then
+  log "trusting mise config and installing tools"
+  mise trust -y
+  mise install
+else
+  log "mise not found, skipping tool install"
+fi
+
+if [[ -f .gitmodules ]]; then
+  log "updating git submodules"
+  git submodule update --init --recursive --jobs=4 --depth=1
+else
+  log "no .gitmodules found, skipping submodules"
+fi
+
+find_primary_worktree() {
+  git worktree list --porcelain | awk '
+    /^worktree / { path=$2 }
+    /^branch refs\/heads\/(main|master)$/ { print path; exit }
+  '
+}
+
+source_worktree="${SOURCE_WORKTREE:-${MAIN_WORKTREE:-}}"
+if [[ -z "$source_worktree" ]]; then
+  source_worktree="$(find_primary_worktree || true)"
+fi
+
+if [[ -n "$source_worktree" && "$source_worktree" != "$repo_root" && -d "$source_worktree" ]]; then
+  log "copying local config from $source_worktree"
+  shopt -s nullglob
+
+  for src in "$source_worktree"/.env "$source_worktree"/.env.* "$source_worktree"/.envrc; do
+    name="$(basename "$src")"
+
+    case "$name" in
+      .env.example|.env.sample|.env.template)
+        continue
+        ;;
+    esac
+
+    target="$repo_root/$name"
+    if [[ -e "$target" ]]; then
+      log "keeping existing $name"
+      continue
+    fi
+
+    cp -p "$src" "$target"
+
+    case "$name" in
+      .env|.env.*)
+        chmod 600 "$target" || true
+        ;;
+    esac
+
+    log "copied $name"
+  done
+
+  shopt -u nullglob
+else
+  log "source worktree not found, skipping local config copy"
+fi
+
+if [[ -f .envrc ]] && command -v direnv >/dev/null 2>&1; then
+  log "allowing direnv for this worktree"
+  direnv allow
+else
+  log "direnv or .envrc not present, skipping direnv allow"
+fi
+
+log "ready"

--- a/scripts/start-task.sh
+++ b/scripts/start-task.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# start-task.sh — orchestration entry point for HW-3.
+#
+# Creates an isolated git worktree under .worktrees/<branch>, runs init.sh
+# inside it, opens a new zellij tab pointing to the worktree and auto-starts
+# the agent chosen by the routing rule (see docs/orchestration/routing.md).
+#
+# Usage:
+#   scripts/start-task.sh <branch-name> [--type <task-type>]
+#                                       [--base <branch>]
+#                                       [--agent <name>]
+#
+# Defaults: --type freeform, --base main.
+# --agent overrides whatever --type would pick.
+# Pass --agent none to skip auto-starting an agent.
+#
+# Requirements: must run inside an active zellij session.
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF' >&2
+Usage: scripts/start-task.sh <branch-name> [--type <task-type>] [--base <branch>] [--agent <name>]
+
+  <branch-name>        new branch + worktree directory under .worktrees/
+  --type <task-type>   routing rule (see docs/orchestration/routing.md):
+                       spec | feature | frontend | bugfix | test | review
+                       | docs | refactor | freeform   (default: freeform)
+  --base <branch>      base branch to fork from (default: main)
+  --agent <name>       override agent: claude | codex | none
+
+Must be executed from inside a zellij session.
+EOF
+  exit 1
+}
+
+log()  { printf '[start-task] %s\n' "$*"; }
+err()  { printf '[start-task] error: %s\n' "$*" >&2; }
+hint() { printf '[start-task] hint: %s\n' "$*"; }
+
+# routing_for <type> -> echoes "<agent>|<hint>"
+# Keep in sync with docs/orchestration/routing.md.
+routing_for() {
+  case "$1" in
+    spec)
+      echo "claude|consider invoking the rails-architecture-analyst sub-agent and the spec-reviewer:spec-review skill" ;;
+    feature)
+      echo "claude|consider invoking the rails-architecture-analyst sub-agent; for UI work also frontend-design" ;;
+    frontend)
+      echo "claude|consider invoking the frontend-design skill and playwright-cli for visual checks" ;;
+    bugfix)
+      echo "claude|consider invoking the rails-architecture-analyst sub-agent to map dependencies before editing" ;;
+    test)
+      echo "claude|consider invoking the rails-qa-test-investigator sub-agent" ;;
+    review)
+      echo "codex|consider running pr-review-fix-loop:codex-pr-review on this branch" ;;
+    docs)
+      echo "claude|consider invoking the sc:document skill" ;;
+    refactor)
+      echo "claude|consider invoking the rails-architecture-analyst sub-agent and avoid behaviour changes" ;;
+    freeform)
+      echo "claude|" ;;
+    *)
+      return 1 ;;
+  esac
+}
+
+[[ $# -lt 1 ]] && usage
+
+branch=""
+base="main"
+agent_override=""
+task_type="freeform"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --type)  task_type="$2"; shift 2 ;;
+    --base)  base="$2"; shift 2 ;;
+    --agent) agent_override="$2"; shift 2 ;;
+    -h|--help) usage ;;
+    --*) err "unknown flag: $1"; usage ;;
+    *)
+      if [[ -z "$branch" ]]; then
+        branch="$1"; shift
+      else
+        err "unexpected argument: $1"; usage
+      fi
+      ;;
+  esac
+done
+
+[[ -z "$branch" ]] && usage
+
+if ! routing_entry="$(routing_for "$task_type")"; then
+  err "unknown --type '$task_type' — see docs/orchestration/routing.md"
+  exit 1
+fi
+
+routed_agent="${routing_entry%%|*}"
+routed_hint="${routing_entry#*|}"
+
+if [[ -n "$agent_override" ]]; then
+  agent="$agent_override"
+else
+  agent="$routed_agent"
+fi
+
+# Codex may be unavailable due to rate limits — fall back transparently.
+if [[ "$agent" == "codex" ]] && ! command -v codex >/dev/null 2>&1; then
+  log "codex not available, falling back to claude (per routing fallback rule)"
+  agent="claude"
+fi
+
+if [[ -z "${ZELLIJ:-}" ]]; then
+  err "must run inside a zellij session — start one with 'zellij' first"
+  exit 1
+fi
+
+if [[ "$agent" != "none" ]] && ! command -v "$agent" >/dev/null 2>&1; then
+  err "agent '$agent' not found in PATH"
+  exit 1
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+if ! git show-ref --verify --quiet "refs/heads/$base"; then
+  err "base branch '$base' does not exist locally"
+  exit 1
+fi
+
+if git show-ref --verify --quiet "refs/heads/$branch"; then
+  err "branch '$branch' already exists — pick a different name or delete it first"
+  exit 1
+fi
+
+worktree_rel=".worktrees/$branch"
+worktree_abs="$repo_root/$worktree_rel"
+
+if [[ -e "$worktree_abs" ]]; then
+  err "path $worktree_rel already exists"
+  exit 1
+fi
+
+mkdir -p "$repo_root/.worktrees"
+
+log "type=$task_type  agent=$agent  base=$base  branch=$branch"
+
+log "creating worktree $worktree_rel from $base"
+git worktree add "$worktree_abs" -b "$branch" "$base"
+
+log "running init in $worktree_rel"
+( cd "$worktree_abs" && SOURCE_WORKTREE="$repo_root" bash scripts/init.sh )
+
+log "opening zellij tab '$branch'"
+zellij action new-tab --cwd "$worktree_abs" --name "$branch"
+
+if [[ "$agent" != "none" ]]; then
+  # Give zellij a moment to focus the new tab before sending keystrokes.
+  sleep 0.3
+  log "launching agent: $agent"
+  zellij action write-chars "$agent"
+  zellij action write-chars $'\n'
+fi
+
+if [[ -n "$routed_hint" ]]; then
+  hint "$routed_hint"
+fi
+
+log "ready — switch to tab '$branch' to interact with the agent"

--- a/video_chat_and_translator/app/frontend/features/videos/transcription/client.ts
+++ b/video_chat_and_translator/app/frontend/features/videos/transcription/client.ts
@@ -22,12 +22,14 @@ export interface TranscribeToVttParams {
 function normalizeUnknownError(provider: TranscriptionProvider, err: unknown): TranscriptionError {
   if (err instanceof TranscriptionError) return err
   if (err instanceof TypeError) {
-    // Most common fetch error in browsers: network/CORS shows up as TypeError.
+    // Browser hides the response body for cross-origin 4xx without CORS headers,
+    // so a rejected API key surfaces here identically to a real network failure.
+    // We can't disambiguate from JS — surface the most likely cause first.
     return new TranscriptionError({
       provider,
       code: 'network',
       message:
-        'Не удалось выполнить запрос к провайдеру. Возможны проблемы сети или CORS (запрос выполняется напрямую из браузера).',
+        'Не удалось получить ответ от провайдера. Наиболее вероятная причина — неверный API key (ответ 401 заблокирован CORS и недоступен из браузера). Также возможны проблемы сети или CORS.',
     })
   }
   const message = err instanceof Error ? err.message : 'Неизвестная ошибка.'

--- a/video_chat_and_translator/spec/frontend/features/videos/transcription/client.test.ts
+++ b/video_chat_and_translator/spec/frontend/features/videos/transcription/client.test.ts
@@ -98,6 +98,35 @@ describe('FT-017 transcription client', () => {
     ).rejects.toMatchObject({ code: 'invalid_api_key' })
   })
 
+  it('surfaces likely invalid API key when CORS hides the 401 response', async () => {
+    class XHRCorsBlocked extends MockXMLHttpRequest {
+      override send() {
+        queueMicrotask(() => {
+          this.emitUploadProgress({ lengthComputable: true, loaded: 100, total: 100 })
+          this.emitUploadLoad()
+          // Browser blocks 4xx without CORS headers → XHR fires `error`, status stays 0.
+          this.emitError()
+        })
+      }
+    }
+    vi.stubGlobal('XMLHttpRequest', XHRCorsBlocked)
+
+    try {
+      await transcribeToVtt({
+        provider: 'openai',
+        apiKey: 'bad',
+        videoFile: new File(['video'], 'video.mp4', { type: 'video/mp4' }),
+        model: 'whisper-1',
+      })
+      throw new Error('expected to reject')
+    } catch (e: unknown) {
+      expect(e).toBeInstanceOf(TranscriptionError)
+      const err = e as TranscriptionError
+      expect(err.code).toBe('network')
+      expect(err.message).toMatch(/API key/i)
+    }
+  })
+
   it('rejects non-vtt response as invalid_response', async () => {
     class XHRBadBody extends MockXMLHttpRequest {
       override send() {


### PR DESCRIPTION
## Summary
- Cross-origin 4xx from OpenAI/Groq are often hidden by CORS, so a rejected API key surfaces in `client.ts` identical to a real network failure (XHR `error`, status 0). The previous user-facing message blamed only network/CORS, leaving the most likely cause — a wrong API key — unmentioned.
- Updated the message in `normalizeUnknownError` (path `code: 'network'`) to lead with **«наиболее вероятная причина — неверный API key»**, keeping network/CORS as alternatives. No code/type/UI changes beyond the string.
- Added a Vitest case that emits the XHR `error` event (CORS-blocked 401) and asserts the message mentions "API key".

## Test plan
- [x] `npm run test -- spec/frontend/features/videos/transcription/client.test.ts` — 6/6 green (5 existing + 1 new).
- [x] `npm run check` (tsc) — clean.
- [ ] Manual: enter a wrong API key in the transcription UI; verify the error banner now begins with the invalid-API-key wording.

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)